### PR TITLE
fix(sonarr): correct word boundary for versions regex

### DIFF
--- a/docs/Sonarr/Sonarr-Release-Profile-RegEx-Anime.md
+++ b/docs/Sonarr/Sonarr-Release-Profile-RegEx-Anime.md
@@ -512,7 +512,7 @@ Add this to your Preferred with a score of **[1]**
 Adds version due to anime groups sometimes fixing issues with their releases.
 
 ```bash
-/\d(v2)\b/i
+/\b(v2)\b/i
 ```
 
 ---
@@ -520,7 +520,7 @@ Adds version due to anime groups sometimes fixing issues with their releases.
 Add this to your Preferred with a score of **[2]**
 
 ```bash
-/\d(v3)\b/i
+/\b(v3)\b/i
 ```
 
 ---
@@ -528,7 +528,7 @@ Add this to your Preferred with a score of **[2]**
 Add this to your Preferred with a score of **[3]**
 
 ```bash
-/\d(v4)\b/i
+/\b(v4)\b/i
 ```
 
 ---


### PR DESCRIPTION
# Pull Request

## Purpose

Fixes the word boundary for versions regex

## Approach

Uses the correct pattern (anchor instead of any digit)

## Open Questions and Pre-Merge TODOs

<!-- - [ ] Use GitHub checklists. When solved, check the box and explain the answer.

<!-- ## Learning

If you're adding a new Custom Format, make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md). -->

## Requirements

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-Guides/Guides/blob/master/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-Guides/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
